### PR TITLE
Change default dtype behaviour

### DIFF
--- a/pylops/basicoperators/CausalIntegration.py
+++ b/pylops/basicoperators/CausalIntegration.py
@@ -71,7 +71,7 @@ class CausalIntegration(LinearOperator):
 
     """
     def __init__(self, N, dims=None, dir=-1, sampling=1,
-                 halfcurrent=True, dtype='float32'):
+                 halfcurrent=True, dtype='float64'):
         self.N = N
         self.dir = dir
         self.sampling = sampling

--- a/pylops/basicoperators/FirstDerivative.py
+++ b/pylops/basicoperators/FirstDerivative.py
@@ -39,7 +39,7 @@ class FirstDerivative(LinearOperator):
         y[i] = (0.5x[i+1] - 0.5x[i-1]) / dx
 
     """
-    def __init__(self, N, dims=None, dir=0, sampling=1., dtype='float32'):
+    def __init__(self, N, dims=None, dir=0, sampling=1., dtype='float64'):
         self.N = N
         self.dir = dir
         self.sampling = sampling

--- a/pylops/basicoperators/Laplacian.py
+++ b/pylops/basicoperators/Laplacian.py
@@ -2,7 +2,7 @@ import numpy as np
 from pylops.basicoperators import SecondDerivative
 
 
-def Laplacian(dims, dirs=(0, 1), weights=(1, 1), sampling=(1, 1), dtype='float32'):
+def Laplacian(dims, dirs=(0, 1), weights=(1, 1), sampling=(1, 1), dtype='float64'):
     r"""Laplacian.
 
     Apply second-order centered laplacian operator to a multi-dimensional array

--- a/pylops/basicoperators/LinearRegression.py
+++ b/pylops/basicoperators/LinearRegression.py
@@ -61,14 +61,17 @@ class LinearRegression(LinearOperator):
         \end{bmatrix}
 
     """
-    def __init__(self, taxis, dtype='float32'):
+    def __init__(self, taxis, dtype=None):
         if not isinstance(taxis, np.ndarray):
             logging.error('t must be numpy.ndarray...')
             raise TypeError('t must be numpy.ndarray...')
         else:
             self.taxis = taxis
         self.shape = (len(self.taxis), 2)
-        self.dtype = np.dtype(dtype)
+        if dtype is None:
+            self.dtype = self.taxis.dtype
+        else:
+            self.dtype = np.dtype(dtype)
         self.explicit = False
 
     def _matvec(self, x):

--- a/pylops/basicoperators/MatrixMult.py
+++ b/pylops/basicoperators/MatrixMult.py
@@ -27,7 +27,7 @@ class MatrixMult(LinearOperator):
         Operator contains a matrix that can be solved explicitly (``True``) or not (``False``)
 
     """
-    def __init__(self, A, dims=None, dtype='float32'):
+    def __init__(self, A, dims=None, dtype=None):
         self.A = A
         if dims is None:
             self.reshape = False
@@ -40,7 +40,10 @@ class MatrixMult(LinearOperator):
             self.shape = (A.shape[0]*np.prod(self.dims),
                           A.shape[1]*np.prod(self.dims))
             self.explicit = False
-        self.dtype = np.dtype(dtype)
+        if dtype is None:
+            self.dtype = A.dtype
+        else:
+            self.dtype = np.dtype(dtype)
 
 
     def _matvec(self, x):

--- a/pylops/basicoperators/Restriction.py
+++ b/pylops/basicoperators/Restriction.py
@@ -26,7 +26,7 @@ class Restriction(LinearOperator):
         Operator contains a matrix that can be solved explicitly (``True``) or not (``False``)
 
     """
-    def __init__(self, N, iava, dtype='float32'):
+    def __init__(self, N, iava, dtype='float64'):
         self.N = N
         self.iava = iava
         self.shape = (len(iava), N)

--- a/pylops/basicoperators/SecondDerivative.py
+++ b/pylops/basicoperators/SecondDerivative.py
@@ -39,7 +39,7 @@ class SecondDerivative(LinearOperator):
         y[i] = (x[i+1] - 2x[i] + x[i-1]) / dx
 
     """
-    def __init__(self, N, dims=None, dir=0, sampling=1, dtype='float32'):
+    def __init__(self, N, dims=None, dir=0, sampling=1, dtype='float64'):
         self.N = N
         self.dir = dir
         self.sampling = sampling

--- a/pylops/basicoperators/Smoothing1D.py
+++ b/pylops/basicoperators/Smoothing1D.py
@@ -1,7 +1,7 @@
 import numpy as np
 from pylops.signalprocessing import Convolve1D
 
-def Smoothing1D(nsmooth, dims, dir=0, dtype='float32'):
+def Smoothing1D(nsmooth, dims, dir=0, dtype='float64'):
     r"""1D Smoothing.
 
     Apply smoothing to model (and data) along a specific direction of a multi-dimensional array

--- a/pylops/basicoperators/Smoothing2D.py
+++ b/pylops/basicoperators/Smoothing2D.py
@@ -2,7 +2,7 @@ import numpy as np
 from pylops.signalprocessing import Convolve2D
 
 
-def Smoothing2D(nsmooth, dims, nodir=None, dtype='float32'):
+def Smoothing2D(nsmooth, dims, nodir=None, dtype='float64'):
     r"""2D Smoothing.
 
     Apply smoothing to model (and data) along two directions of a multi-dimensional array


### PR DESCRIPTION
As discussed.

My suggestion is two-fold.

## 1. If input contains an `ndarray`
Set default to `None`, and if `None`, take the `dtype` of the input array. Example where the input contains the matrix `A`.
```
if dtype is None:
    self.dtype = A.dtype
else:
    self.dtype = np.dtype(dtype)
```

## 2. If input does not contain an `ndarray`
Change default from `float32` to `float64`. This is the default in `NumPy`/`SciPy`, so users most likely expect `float64` unless they specifically specify it otherwise.