### PR TITLE
Typo which caused wrong rendering

### DIFF
--- a/tutorials/optimization.py
+++ b/tutorials/optimization.py
@@ -183,11 +183,13 @@ xreg = pylops.optimization.leastsquares.RegularizedInversion(Rop, [D2op], y,
 #   .. math::
 #       J= ||\mathbf{y} - \mathbf{R} \mathbf{P} \mathbf{p}||_2
 #
-# where :math:`\mathbf{P}` is the precondioned operator, :math:`\mathbf{p}` is the projected model
-# in the preconditioned space, and :math:`\mathbf{x}=\mathbf{P}\mathbf{p}`is the model in
-# the original model space we want to solve for. Note that a preconditioned problem converges
-# much faster to its solution than its corresponding regularized problem. This can be done
-# using the routine :py:func:`pylops.optimization.leastsquares.PreconditionedInversion`.
+# where :math:`\mathbf{P}` is the precondioned operator, :math:`\mathbf{p}` is
+# the projected model in the preconditioned space, and
+# :math:`\mathbf{x}=\mathbf{P}\mathbf{p}` is the model in the original model
+# space we want to solve for. Note that a preconditioned problem converges much
+# faster to its solution than its corresponding regularized problem. This can
+# be done using the routine
+# :py:func:`pylops.optimization.leastsquares.PreconditionedInversion`.
 
 # Create regularization operator
 Sop = pylops.Smoothing1D(nsmooth=11, dims=[N], dtype='float64')


### PR DESCRIPTION
Fix a typo which caused wrong rendering in the Tutorial:

![2018-12-23_01](https://user-images.githubusercontent.com/8020943/50389097-e411da80-06ea-11e9-863b-6e4c165e3c80.jpg)
