### PR TITLE
Remove dependency to imageio

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -17,5 +17,3 @@ dependencies:
     - sphinx-gallery
     - nbsphinx
     - image
-    - Pillow
-    - imageio

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,6 +10,4 @@ sphinx-rtd-theme
 sphinx-gallery
 numpydoc
 nbsphinx
-Pillow
 image
-imageio

--- a/tutorials/deblurring.py
+++ b/tutorials/deblurring.py
@@ -15,12 +15,14 @@ of the point-spread function.
 """
 import numpy as np
 import matplotlib.pyplot as plt
-import imageio
+from scipy import misc
+
 import pylops
 
 ###############################################################################
 # Let's start by importing a 2d image and defining the blurring operator
-im = np.asarray(imageio.imread('../testdata/python.png'))[::5, ::5, 0]
+im = np.asarray(misc.imread('../testdata/python.png'))[::5, ::5, 0]
+
 Nz, Nx = im.shape
 
 # Blurring guassian operator

--- a/tutorials/interpolation.py
+++ b/tutorials/interpolation.py
@@ -26,7 +26,8 @@ with :math:`M>>N`.
 """
 import numpy as np
 import matplotlib.pyplot as plt
-import imageio
+from scipy import misc
+
 import pylops
 
 plt.close('all')
@@ -34,7 +35,7 @@ plt.close('all')
 ###############################################################################
 # To start we import a 2d image and define our restriction operator to irregularly and randomly
 # sample the image for 30% of the entire grid
-im = np.asarray(imageio.imread('../testdata/python.png'))[:, :, 0]
+im = np.asarray(misc.imread('../testdata/python.png'))[:, :, 0]
 Nz, Nx = im.shape
 N = Nz * Nx
 


### PR DESCRIPTION
Remove dependency to imageio and go back to scipy to read images. Imageio did not work in readthedocs as it kept finding PIL instead of Pillow