### PR TITLE
Update LinearOperator.py

### DIFF
--- a/pylops/LinearOperator.py
+++ b/pylops/LinearOperator.py
@@ -17,7 +17,6 @@ class LinearOperator(spLinearOperator):
 
     """
     def __init__(self, explicit=False):
-        super(LinearOperator, self).__init__()
         self.explicit = explicit
 
     def div(self, y):


### PR DESCRIPTION
Do not call `super`.

    super(LinearOperator, self).__init__()

actually calls re-initializes the class again because

    from scipy.sparse.linalg import LinearOperator as spLinearOperator

aliases  `LinearOperator` to `spLinearOperator` and the current class is defined as

    class LinearOperator(spLinearOperator):


On the other hand, calling `spLinearOperator` [would require `self.shape` and `self.dtype` to be implemented](http://weinbe58.github.io/QuSpin/modules/scipy/sparse/linalg/interface.html). For future reference, if the super class needs to be instantiated, just do `super().__init__()` as described in [the docs](https://docs.python.org/3/library/functions.html#super).